### PR TITLE
Add ability to create a project without naming it

### DIFF
--- a/FlowBoard/Helpers/FileHelper.cs
+++ b/FlowBoard/Helpers/FileHelper.cs
@@ -18,6 +18,7 @@ using Windows.Graphics.Imaging;
 using Windows.Graphics.Display;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Collections.ObjectModel;
+using System.Text.RegularExpressions;
 
 namespace FlowBoard.Helpers
 {
@@ -146,6 +147,24 @@ namespace FlowBoard.Helpers
         {
             var item = await ApplicationData.Current.LocalFolder.TryGetItemAsync(fileName);
             return item != null;
+        }
+
+        public static async Task<string> GetSequentialNewWhiteboardFilename()
+        {
+            Regex rx = new Regex(@"(New Whiteboard$|New Whiteboard \(([0-9]+)\)$)");
+
+            int highestNumber = -1;
+            var items = await ApplicationData.Current.LocalFolder.GetItemsAsync();
+            foreach (var item in items)
+            {
+                foreach (Match match in rx.Matches(item.Name))
+                {
+                    highestNumber = match.Groups[2].Length == 0 ? 0 : int.Parse(match.Groups[2].Value);
+                }
+            }
+
+            string postfix = highestNumber < 0 ? "" : " (" + (highestNumber + 1).ToString() + ")";
+            return "New Whiteboard" + postfix;
         }
 
         // Save the project + add it to the most recently used list + get a preview image

--- a/FlowBoard/NewProjectPage.xaml
+++ b/FlowBoard/NewProjectPage.xaml
@@ -42,13 +42,13 @@
                     <TextBlock FontSize="24" FontWeight="SemiBold" Margin="0, 0, 0, 12">New Project</TextBlock>
                     <TextBlock FontWeight="SemiBold">Project Name:</TextBlock>
                     <toolkit:DropShadowPanel ShadowOpacity="0.4" OffsetX="4" CornerRadius="8" Margin="0, 12, 0, 16" OffsetY="4">
-                        <TextBox x:Name="Name" Height="20" Width="340" PlaceholderText="New Project" Style="{ThemeResource GlowTextBox}"/>
+                        <TextBox x:Name="Name" Height="20" Width="340" PlaceholderText="New Whiteboard" Style="{ThemeResource GlowTextBox}"/>
                     </toolkit:DropShadowPanel>
                     <TextBlock FontWeight="SemiBold">Canvas Background:</TextBlock>
                     <controls:BackgroundSelectorControl x:Name="Backgrounds" SelectedIndex="0" Margin="8, 12, 0, 12"/>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" >
                         <TextBlock x:Name="Status" Foreground="Red" Width="250" TextWrapping="WrapWholeWords" Margin="0, 0, 4, 0"/>
-                        <Button IsEnabled="{x:Bind helpers:UIHelper.TextToBool(Name.Text), Mode=OneWay}" Width="80" Click="CreateProject_Click">Create</Button>
+                        <Button Width="80" Click="CreateProject_Click">Create</Button>
                     </StackPanel>
                 </StackPanel>
             </Grid>

--- a/FlowBoard/NewProjectPage.xaml.cs
+++ b/FlowBoard/NewProjectPage.xaml.cs
@@ -40,9 +40,15 @@ namespace FlowBoard
             await Task.Run(() =>
                 CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
                 {
+                    string fileName = Name.Text;
+                    if (fileName == "")
+                    {
+                        fileName = await FileHelper.GetSequentialNewWhiteboardFilename();
+                    }
+
                     try
                     {
-                        if (await FileHelper.IsFilePresent(Name.Text))
+                        if (Name.Text != "" && await FileHelper.IsFilePresent(fileName))
                         {
                             Ring.Visibility = Visibility.Collapsed;
                             Content.Opacity = 1;
@@ -58,7 +64,7 @@ namespace FlowBoard
                         Status.Text = "Invalid project name";
                         return;
                     }
-                    bool success = await FileHelper.CreateProjectAsync(Name.Text, UIHelper.IndexToColor(Backgrounds.SelectedIndex).Color);
+                    bool success = await FileHelper.CreateProjectAsync(fileName, UIHelper.IndexToColor(Backgrounds.SelectedIndex).Color);
                     if(!success)
                     {
                         Ring.Visibility = Visibility.Collapsed;


### PR DESCRIPTION
For some people (including myself), it's crucial to to get to writing immediately without being forced to name the whiteboard. This PR allows the "Create" button to be pressed when the project name is empty, and will automatically use the a non-conflicting name of the form `New Whiteboard` or `New Whiteboard (n)`